### PR TITLE
Add dark mode toggle component

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3,7 +3,7 @@
 
 @layer base {
   body {
-    @apply font-noto bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100;
+    @apply bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100;
   }
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,12 @@
 @import "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100..900&display=swap");
 
+@layer base {
+  body {
+    @apply font-noto bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100;
+  }
+}
+
 @layer utilities {
   .text-shadow {
     text-shadow: rgba(0, 0, 0, 0.7) 2px 2px 3px;

--- a/src/app.css
+++ b/src/app.css
@@ -3,7 +3,10 @@
 
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100;
+    @apply bg-gray-50 text-gray-800;
+  }
+  .dark body {
+    @apply bg-gray-900 text-gray-100;
   }
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -11,8 +11,4 @@
   .text-shadow {
     text-shadow: rgba(0, 0, 0, 0.7) 2px 2px 3px;
   }
-
-  .font-noto {
-    font-family: "Noto Sans TC", sans-serif;
-  }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" class="bg-gray-100 font-noto">
+  <body data-sveltekit-preload-data="hover" class="font-noto">
     %sveltekit.body%
   </body>
 </html>

--- a/src/lib/components/AreaCard.svelte
+++ b/src/lib/components/AreaCard.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <li class="p-2 rounded-lg">
-  <article class="shadow rounded-lg bg-white flex flex-col">
+  <article class="shadow rounded-lg bg-white dark:bg-gray-800 flex flex-col">
     <header
       class="relative rounded-lg p-3 flex justify-between items-end bg-cover bg-center h-40"
       style="background-image:url({info.Picture1})"
@@ -21,7 +21,7 @@
         >{info.Zone}</span
       >
     </header>
-    <footer class="text-sm p-3 text-gray-800 space-y-2">
+    <footer class="text-sm p-3 text-gray-800 dark:text-gray-200 space-y-2">
       <p><i class="fas fa-clock"></i> {info.Opentime}</p>
       <p><i class="fas fa-home"></i> {info.Add}</p>
       <p><i class="fas fa-phone-alt"></i> {info.Tel}</p>

--- a/src/lib/components/AreaCard.svelte
+++ b/src/lib/components/AreaCard.svelte
@@ -21,7 +21,7 @@
         >{info.Zone}</span
       >
     </header>
-    <footer class="text-sm p-3 text-gray-800 dark:text-gray-200 space-y-2">
+    <footer class="text-sm p-3 text-gray-800 dark:text-gray-200 dark:bg-gray-700 space-y-2">
       <p><i class="fas fa-clock"></i> {info.Opentime}</p>
       <p><i class="fas fa-home"></i> {info.Add}</p>
       <p><i class="fas fa-phone-alt"></i> {info.Tel}</p>

--- a/src/lib/components/AreaSelect.svelte
+++ b/src/lib/components/AreaSelect.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <select
-  class="w-full mt-4 mb-5 border rounded p-2 bg-white/80 backdrop-blur text-gray-700 dark:bg-gray-700/80 dark:border-gray-600 dark:text-gray-200"
+  class="w-full mt-4 mb-5 border rounded p-2 bg-white backdrop-blur text-gray-700 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
   on:change={handleChange}
   bind:value={selected}
 >

--- a/src/lib/components/AreaSelect.svelte
+++ b/src/lib/components/AreaSelect.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <select
-  class="w-full mt-4 mb-5 border rounded p-2 bg-white/80 backdrop-blur text-gray-700"
+  class="w-full mt-4 mb-5 border rounded p-2 bg-white/80 backdrop-blur text-gray-700 dark:bg-gray-700/80 dark:border-gray-600 dark:text-gray-200"
   on:change={handleChange}
   bind:value={selected}
 >

--- a/src/lib/components/HotButtons.svelte
+++ b/src/lib/components/HotButtons.svelte
@@ -8,7 +8,7 @@
 >
   {#each hotAreas as area}
     <button
-      class="rounded-full px-4 py-1 bg-blue-500 text-white hover:bg-blue-600 w-full sm:w-auto"
+      class="rounded-full px-4 py-1 bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-700 dark:hover:bg-blue-800 w-full sm:w-auto"
       on:click={() => onSelect?.(area)}
     >
       {area}

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  let dark = false;
+
+  onMount(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      dark = true;
+      document.documentElement.classList.add('dark');
+    }
+  });
+
+  function toggle() {
+    dark = !dark;
+    if (dark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }
+</script>
+
+<button
+  class="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-blue-500 text-white flex items-center justify-center shadow-lg dark:bg-blue-700"
+  on:click={toggle}
+  aria-label="Toggle theme"
+>
+  {#if dark}
+    🌙
+  {:else}
+    ☀️
+  {/if}
+</button>
+

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -7,6 +7,9 @@
     if (stored === 'dark') {
       dark = true;
       document.documentElement.classList.add('dark');
+    } else {
+      localStorage.setItem('theme', 'light');
+      document.documentElement.classList.remove('dark');
     }
   });
 

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -6,15 +6,11 @@
     const stored = localStorage.getItem('theme');
     if (stored === 'dark') {
       dark = true;
-      document.documentElement.classList.add('dark');
-    } else {
-      localStorage.setItem('theme', 'light');
-      document.documentElement.classList.remove('dark');
     }
+    updateTheme();
   });
 
-  function toggle() {
-    dark = !dark;
+  function updateTheme() {
     if (dark) {
       document.documentElement.classList.add('dark');
       localStorage.setItem('theme', 'dark');
@@ -22,6 +18,11 @@
       document.documentElement.classList.remove('dark');
       localStorage.setItem('theme', 'light');
     }
+  }
+
+  function toggle() {
+    dark = !dark;
+    updateTheme();
   }
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script>
   import "../app.css";
+  import ThemeToggle from "$lib/components/ThemeToggle.svelte";
 </script>
 
 <slot />
+<ThemeToggle />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,7 +54,7 @@
     <h2 class="text-gray-600 dark:text-gray-100 mb-2 text-2xl">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
-  <h3 class="text-center my-4 text-2xl font-bold">
+  <h3 class="text-center my-4 text-2xl font-bold text-gray-800 dark:text-gray-100">
     {selected || "全部景點"}
   </h3>
   {#if filtered.length > 0}
@@ -64,6 +64,6 @@
       {/each}
     </ul>
   {:else}
-    <p class="text-center my-4 text-2xl">目前沒有任何景點</p>
+    <p class="text-center my-4 text-2xl text-gray-800 dark:text-gray-100">目前沒有任何景點</p>
   {/if}
 </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -49,9 +49,9 @@
 </header>
 <main class="container mx-auto pb-8">
   <div
-    class="-mt-10 bg-white/75 backdrop-blur mx-2 shadow rounded-3xl text-center py-4 px-6"
+    class="-mt-10 bg-white/75 dark:bg-gray-800/75 backdrop-blur mx-2 shadow rounded-3xl text-center py-4 px-6"
   >
-    <h2 class="text-gray-500 mb-2 text-2xl">💯 熱門景點 💯</h2>
+    <h2 class="text-gray-500 dark:text-gray-300 mb-2 text-2xl">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
   <h3 class="text-center my-4 text-2xl font-bold">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,7 +51,7 @@
   <div
     class="-mt-10 bg-white/75 dark:bg-gray-800/75 backdrop-blur mx-2 shadow rounded-3xl text-center py-4 px-6"
   >
-    <h2 class="text-gray-500 dark:text-gray-300 mb-2 text-2xl">💯 熱門景點 💯</h2>
+    <h2 class="text-gray-600 dark:text-gray-100 mb-2 text-2xl">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
   <h3 class="text-center my-4 text-2xl font-bold">

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{html,js,svelte,ts}"],
   theme: {
     extend: {},

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,11 @@ module.exports = {
   darkMode: 'class',
   content: ["./src/**/*.{html,js,svelte,ts}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        noto: ['"Noto Sans TC"', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind config
- define base styles for light/dark backgrounds and text
- implement circular theme toggle component fixed at bottom-right
- adjust page and component styles for dark mode

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684520cac3108330bc4d8caed300ccee