### PR TITLE
Add title and meta description

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,4 +2,9 @@
   import "../app.css";
 </script>
 
+<svelte:head>
+  <title>高雄市旅遊資訊網 | Kaohsiung City Travel Info</title>
+  <meta name="description" content="提供高雄市各區景點資訊、開放時間、地址、電話及票價查詢，並可依區域篩選和瀏覽熱門景點。" />
+</svelte:head>
+
 <slot />


### PR DESCRIPTION
## Summary
- add site-wide title and meta description in layout

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68453436dbbc8330b3bc261cf993c24d