### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" class="bg-gray-100 font-noto">
+  <body data-sveltekit-preload-data="hover" class="font-noto">
     %sveltekit.body%
   </body>
 </html>

--- a/src/lib/components/AreaCard.svelte
+++ b/src/lib/components/AreaCard.svelte
@@ -5,7 +5,7 @@
 
 <!-- 單一景點卡片 -->
 <li class="rounded-lg p-2">
-  <article class="flex flex-col rounded-lg bg-white shadow">
+  <article class="flex flex-col rounded-lg bg-white shadow dark:bg-gray-700 dark:text-gray-100">
     <!-- 圖片與區域標籤 -->
     <header
       class="relative flex justify-between items-end h-40 p-3 rounded-lg bg-cover bg-center"
@@ -25,7 +25,7 @@
       >
     </header>
     <!-- 營業資訊 -->
-    <footer class="space-y-2 p-3 text-sm text-gray-800">
+    <footer class="space-y-2 p-3 text-sm text-gray-800 dark:text-gray-100">
       <p><i class="fas fa-clock"></i> {info.Opentime}</p>
       <p><i class="fas fa-home"></i> {info.Add}</p>
       <p><i class="fas fa-phone-alt"></i> {info.Tel}</p>

--- a/src/lib/components/AreaCard.svelte
+++ b/src/lib/components/AreaCard.svelte
@@ -13,14 +13,14 @@
     >
       {#if info.Ticketinfo === "免費參觀"}
         <div
-          class="absolute top-3 left-3 rounded bg-green-700 px-2 py-1 text-sm text-white"
+          class="absolute top-3 left-3 rounded bg-green-700 px-2 py-1 text-sm text-white dark:bg-green-600"
         >
           <i class="fas fa-tags"></i> 免費
         </div>
       {/if}
       <p class="mt-4 text-white text-shadow">{info.Name}</p>
       <span
-        class="rounded bg-red-700 px-2 py-1 text-sm text-white whitespace-nowrap"
+        class="rounded bg-red-700 px-2 py-1 text-sm text-white whitespace-nowrap dark:bg-red-600"
         >{info.Zone}</span
       >
     </header>

--- a/src/lib/components/AreaSelect.svelte
+++ b/src/lib/components/AreaSelect.svelte
@@ -15,7 +15,7 @@
 
 <!-- 區域選擇下拉選單 -->
 <select
-  class="w-full mt-4 mb-5 p-2 border rounded bg-white/80 backdrop-blur text-gray-700"
+  class="w-full mt-4 mb-5 p-2 border rounded bg-white/80 backdrop-blur text-gray-700 dark:bg-gray-600 dark:border-gray-500 dark:text-gray-200"
   on:change={handleChange}
   bind:value={selected}
 >

--- a/src/lib/components/DarkModeToggle.svelte
+++ b/src/lib/components/DarkModeToggle.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { isDark } from '../stores/theme';
+  const toggle = () => {
+    isDark.update(v => !v);
+  };
+</script>
+
+<button
+  class="fixed bottom-4 right-4 w-12 h-12 rounded-full flex items-center justify-center bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-800 shadow-lg"
+  on:click={toggle}
+  aria-label="Toggle color scheme"
+>
+  {#if $isDark}
+    <i class="fas fa-sun"></i>
+  {:else}
+    <i class="fas fa-moon"></i>
+  {/if}
+</button>

--- a/src/lib/components/HotButtons.svelte
+++ b/src/lib/components/HotButtons.svelte
@@ -11,7 +11,7 @@
 >
   {#each hotAreas as area}
     <button
-      class="w-full sm:w-auto rounded-full px-4 py-1 bg-blue-700 hover:bg-blue-900 text-white"
+      class="w-full sm:w-auto rounded-full px-4 py-1 bg-blue-700 hover:bg-blue-900 text-white dark:bg-blue-600 dark:hover:bg-blue-800"
       on:click={() => onSelect?.(area)}
     >
       {area}

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -1,0 +1,18 @@
+import { writable } from 'svelte/store';
+
+const initial = typeof localStorage !== 'undefined'
+  ? localStorage.getItem('theme') === 'dark'
+  : false;
+
+export const isDark = writable(initial);
+
+isDark.subscribe((value) => {
+  if (typeof document !== 'undefined') {
+    document.body.classList.toggle('dark', value);
+    document.body.classList.toggle('bg-gray-100', !value);
+    document.body.classList.toggle('bg-gray-900', value);
+    try {
+      localStorage.setItem('theme', value ? 'dark' : 'light');
+    } catch {}
+  }
+});

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -8,7 +8,8 @@ export const isDark = writable(initial);
 
 isDark.subscribe((value) => {
   if (typeof document !== 'undefined') {
-    document.body.classList.toggle('dark', value);
+    const html = document.documentElement;
+    html.classList.toggle('dark', value);
     document.body.classList.toggle('bg-gray-100', !value);
     document.body.classList.toggle('bg-gray-900', value);
     try {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script>
   import "../app.css";
+  import DarkModeToggle from "$lib/components/DarkModeToggle.svelte";
+  import { isDark } from "$lib/stores/theme";
 </script>
 
 <svelte:head>
@@ -8,3 +10,4 @@
 </svelte:head>
 
 <slot />
+<DarkModeToggle />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,9 +62,9 @@
 <!-- 主要內容 -->
 <main class="container mx-auto pb-8">
   <div
-    class="-mt-10 mx-2 text-center rounded-3xl shadow bg-white/75 backdrop-blur py-4 px-6"
+    class="-mt-10 mx-2 text-center rounded-3xl shadow bg-white/75 backdrop-blur dark:bg-gray-700/70 py-4 px-6"
   >
-    <h2 class="mb-2 text-2xl text-gray-500">💯 熱門景點 💯</h2>
+    <h2 class="mb-2 text-2xl text-gray-500 dark:text-gray-300">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
   <h3 class="my-4 text-center text-2xl font-bold">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,10 +53,10 @@
 
 <!-- 頁面頂部 -->
 <header
-  class="bg-[url('/bg.webp')] bg-cover bg-center p-8 sm:p-12 text-center text-white"
+  class="bg-[url('/bg.webp')] bg-cover bg-center p-8 sm:p-12 text-center text-white dark:bg-gray-900"
 >
-  <h1 class="text-shadow text-3xl sm:text-4xl font-bold">高雄市旅遊資訊網</h1>
-  <p class="text-shadow text-2xl">Kaohsiung City Travel Info</p>
+  <h1 class="text-shadow text-3xl sm:text-4xl font-bold dark:text-gray-100">高雄市旅遊資訊網</h1>
+  <p class="text-shadow text-2xl dark:text-gray-300">Kaohsiung City Travel Info</p>
   <AreaSelect {areas} {selected} onChange={handleSelect} />
 </header>
 <!-- 主要內容 -->
@@ -67,7 +67,7 @@
     <h2 class="mb-2 text-2xl text-gray-500 dark:text-gray-300">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
-  <h3 class="my-4 text-center text-2xl font-bold">
+  <h3 class="my-4 text-center text-2xl font-bold dark:text-gray-100">
     {selected || "全部景點"}
   </h3>
   {#if filtered.length > 0}
@@ -77,6 +77,6 @@
       {/each}
     </ul>
   {:else}
-    <p class="my-4 text-center text-2xl">目前沒有任何景點</p>
+    <p class="my-4 text-center text-2xl dark:text-gray-300">目前沒有任何景點</p>
   {/if}
 </main>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   content: ["./src/**/*.{html,js,svelte,ts}"],
+  darkMode: "class",
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode via class strategy
- add a theme store to manage body classes and persistence
- create a `DarkModeToggle` button fixed to the bottom-right
- integrate the toggle into the site layout
- adjust page and component styles for dark mode
- remove the hard-coded body background

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453881daa483309d4324be28b392fd