### PR TITLE
Add dark mode toggle and refresh dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## 開發環境
 
+- Node.js 20.19 以上（建議使用 `nvm use 22` 對齊 SvelteKit 官方需求）
+
 ```bash
 npm install
 npm run dev
@@ -23,6 +25,10 @@ npm run dev
 - `src/lib/components`：元件 (選單、熱門按鈕、景點卡片)
 - `src/routes`：頁面路由
 - `static`：靜態資源，如 `favicon.webp`
+
+## 功能亮點
+
+- 右下角的「深／淺色模式」浮動按鈕，會根據系統偏好初始化並記錄使用者選擇，卡片、分頁與載入骨架都會隨主題同步換色。
 
 ## 部署
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,17 @@
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^7.0.0",
-        "@sveltejs/kit": "^2.49.0",
+        "@sveltejs/kit": "^2.49.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tailwindcss/cli": "^4.1.17",
         "@tailwindcss/postcss": "^4.1.17",
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
-        "svelte": "^5.45.2",
+        "svelte": "^5.45.6",
         "svelte-check": "^4.3.4",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3",
-        "vite": "^7.2.4"
+        "vite": "^7.2.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.0.tgz",
-      "integrity": "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA==",
+      "version": "2.49.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.1.tgz",
+      "integrity": "sha512-vByReCTTdlNM80vva8alAQC80HcOiHLkd8XAxIiKghKSHcqeNfyhp3VsYAV8VSiPKu4Jc8wWCfsZNAIvd1uCqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1804,9 +1804,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.0.tgz",
-      "integrity": "sha512-WBmtxe7R9C5mvL4n2le8nMUe4mD5V9oiK2vJpQ9I3y20ENPUomPcphBXE8D1x/Bm84oN1V+lOfgXxtqmxTp3Xg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
+      "integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.45.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.45.2.tgz",
-      "integrity": "sha512-yyXdW2u3H0H/zxxWoGwJoQlRgaSJLp+Vhktv12iRw2WRDlKqUPT54Fi0K/PkXqrdkcQ98aBazpy0AH4BCBVfoA==",
+      "version": "5.45.6",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.45.6.tgz",
+      "integrity": "sha512-V3aVXthzPyPt1UB1wLEoXnEXpwPsvs7NHrR0xkCor8c11v71VqBj477MClqPZYyrcXrAH21sNGhOj9FJvSwXfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2478,7 +2478,7 @@
         "clsx": "^2.1.1",
         "devalue": "^5.5.0",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.0",
+        "esrap": "^2.2.1",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -2616,9 +2616,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
-      "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
+      "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^7.0.0",
-    "@sveltejs/kit": "^2.49.0",
+    "@sveltejs/kit": "^2.49.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tailwindcss/cli": "^4.1.17",
     "@tailwindcss/postcss": "^4.1.17",
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
-    "svelte": "^5.45.2",
+    "svelte": "^5.45.6",
     "svelte-check": "^4.3.4",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vite": "^7.2.4"
+    "vite": "^7.2.6"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.17"

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,26 @@
 @import "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100..900&display=swap");
 
+@layer base {
+  :root {
+    color-scheme: light;
+    --card-surface: #ffffff;
+    --card-muted: #475569;
+    --card-border: #e2e8f0;
+  }
+
+  :root.dark {
+    color-scheme: dark;
+    --card-surface: #0f172a;
+    --card-muted: #cbd5e1;
+    --card-border: #1f2937;
+  }
+
+  body {
+    font-family: "Noto Sans TC", sans-serif;
+  }
+}
+
 /* 客製化的工具類別，搭配 Tailwind 使用 */
 @layer utilities {
   .text-shadow {

--- a/src/lib/components/AreaCard.svelte
+++ b/src/lib/components/AreaCard.svelte
@@ -4,8 +4,8 @@
 </script>
 
 <!-- 單一景點卡片 -->
-<li class="rounded-xl bg-gradient-to-br from-indigo-50/70 via-white to-violet-50/60 p-0.5">
-  <article class="flex h-full flex-col rounded-[1rem] border border-indigo-100/80 bg-white shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl">
+<li class="rounded-xl bg-gradient-to-br from-indigo-50/70 via-white to-violet-50/60 p-0.5 dark:from-slate-800/60 dark:via-slate-900/70 dark:to-slate-800/60">
+  <article class="flex h-full flex-col rounded-[1rem] border border-indigo-100/80 bg-white text-slate-800 shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-[var(--card-border)] dark:bg-[var(--card-surface)] dark:text-[var(--card-muted)]">
     <!-- 圖片與區域標籤 -->
     <header
       class="relative flex h-40 items-end justify-between overflow-hidden rounded-t-[1rem] bg-cover bg-center p-3"
@@ -29,7 +29,7 @@
       </div>
     </header>
     <!-- 營業資訊 -->
-    <footer class="space-y-2 border-t border-indigo-50 bg-white/90 p-4 text-sm text-slate-700">
+    <footer class="space-y-2 border-t border-indigo-50 bg-white/90 p-4 text-sm text-slate-700 dark:border-[var(--card-border)] dark:bg-[var(--card-surface)] dark:text-[var(--card-muted)]">
       <p class="flex items-start gap-2">
         <i class="fas fa-clock pt-0.5 text-indigo-500"></i>
         <span>{info.Opentime}</span>

--- a/src/lib/components/AreaSelect.svelte
+++ b/src/lib/components/AreaSelect.svelte
@@ -17,7 +17,7 @@
 <label class="sr-only" for="area-select">選擇行政區域</label>
 <select
   id="area-select"
-  class="w-full mt-4 mb-5 rounded-lg border border-indigo-200 bg-white/80 p-2 text-slate-700 shadow-sm backdrop-blur-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+  class="w-full mt-4 mb-5 rounded-lg border border-indigo-200 bg-white/80 p-2 text-slate-700 shadow-sm backdrop-blur-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-100 dark:focus:border-indigo-300 dark:focus:ring-indigo-300"
   on:change={handleChange}
   bind:value={selected}
 >

--- a/src/lib/components/HotButtons.svelte
+++ b/src/lib/components/HotButtons.svelte
@@ -11,7 +11,7 @@
 >
   {#each hotAreas as area}
     <button
-      class="w-full rounded-full bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-medium text-white shadow transition hover:from-indigo-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:ring-offset-2 focus:ring-offset-white"
+      class="w-full rounded-full bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-medium text-white shadow transition hover:from-indigo-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:ring-offset-2 focus:ring-offset-white dark:from-indigo-400 dark:to-violet-500 dark:hover:from-indigo-500 dark:hover:to-violet-600 dark:focus:ring-indigo-300 dark:focus:ring-offset-slate-900"
       on:click={() => onSelect?.(area)}
     >
       {area}

--- a/src/lib/components/LoadingSkeleton.svelte
+++ b/src/lib/components/LoadingSkeleton.svelte
@@ -6,19 +6,19 @@
 
 <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
   {#each placeholders as _, index (index)}
-    <li class="rounded-xl bg-gradient-to-br from-indigo-50/70 via-white to-violet-50/60 p-0.5">
-      <div class="flex h-full flex-col rounded-[1rem] border border-indigo-100/80 bg-white shadow-md">
-        <div class="relative flex h-40 items-end overflow-hidden rounded-t-[1rem] bg-slate-200/80">
+    <li class="rounded-xl bg-gradient-to-br from-indigo-50/70 via-white to-violet-50/60 p-0.5 dark:from-slate-800/60 dark:via-slate-900/70 dark:to-slate-800/60">
+      <div class="flex h-full flex-col rounded-[1rem] border border-indigo-100/80 bg-white shadow-md dark:border-[var(--card-border)] dark:bg-[var(--card-surface)]">
+        <div class="relative flex h-40 items-end overflow-hidden rounded-t-[1rem] bg-slate-200/80 dark:bg-slate-700/70">
           <div class="absolute inset-0 animate-[shimmer_1.6s_infinite] bg-[linear-gradient(90deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.6)_50%,rgba(255,255,255,0)_100%)] bg-[length:200%_100%]"></div>
           <div class="relative z-10 flex w-full items-end justify-between gap-2 px-3 pb-3">
-            <div class="h-4 w-2/3 rounded-full bg-slate-300/80"></div>
-            <div class="h-6 w-16 rounded-full bg-slate-300/80"></div>
+            <div class="h-4 w-2/3 rounded-full bg-slate-300/80 dark:bg-slate-600"></div>
+            <div class="h-6 w-16 rounded-full bg-slate-300/80 dark:bg-slate-600"></div>
           </div>
         </div>
-        <div class="space-y-3 border-t border-indigo-50 bg-white/90 p-4">
-          <div class="h-4 w-3/4 rounded-full bg-slate-200"></div>
-          <div class="h-4 w-5/6 rounded-full bg-slate-200"></div>
-          <div class="h-4 w-1/2 rounded-full bg-slate-200"></div>
+        <div class="space-y-3 border-t border-indigo-50 bg-white/90 p-4 dark:border-[var(--card-border)] dark:bg-[var(--card-surface)]">
+          <div class="h-4 w-3/4 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+          <div class="h-4 w-5/6 rounded-full bg-slate-200 dark:bg-slate-700"></div>
+          <div class="h-4 w-1/2 rounded-full bg-slate-200 dark:bg-slate-700"></div>
         </div>
       </div>
     </li>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <button
-  class="fixed bottom-5 right-5 z-50 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:scale-105 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+  class="fixed bottom-5 right-5 z-50 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:scale-105 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 dark:bg-indigo-500 dark:hover:bg-indigo-400 cursor-pointer"
   type="button"
   aria-pressed={theme === "dark"}
   aria-label={label}

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  type Theme = "light" | "dark";
+  export let theme: Theme = "light";
+
+  const dispatch = createEventDispatcher();
+  $: label = theme === "dark" ? "切換為淺色" : "切換為深色";
+</script>
+
+<button
+  class="fixed bottom-5 right-5 z-50 inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:scale-105 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+  type="button"
+  aria-pressed={theme === "dark"}
+  aria-label={label}
+  on:click={() => dispatch("toggle")}
+>
+  <span class="text-lg" aria-hidden="true">{theme === "dark" ? "☀️" : "🌙"}</span>
+  <span class="hidden sm:inline">{theme === "dark" ? "淺色模式" : "深色模式"}</span>
+</button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,34 @@
 <script lang="ts">
-  // 引入全域樣式，確保所有頁面共用 Tailwind 設定
+  // 全域樣式
   import "../app.css";
+
+  import { onMount } from "svelte";
+  import ThemeToggle from "$lib/components/ThemeToggle.svelte";
+
+  type Theme = "light" | "dark";
+
+  const STORAGE_KEY = "kaohsiung-travel-theme";
+  let theme: Theme = "light";
+
+  /**
+   * 套用主題到 documentElement，並持久化設定。
+   * 使用 Svelte 推薦的 onMount 觸發，避免在 SSR 階段觸碰瀏覽器 API。
+   */
+  const applyTheme = (value: Theme) => {
+    theme = value;
+    const root = document.documentElement;
+    root.classList.toggle("dark", value === "dark");
+    root.dataset.theme = value;
+    localStorage.setItem(STORAGE_KEY, value);
+  };
+
+  const toggleTheme = () => applyTheme(theme === "light" ? "dark" : "light");
+
+  onMount(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    applyTheme(stored ?? (prefersDark ? "dark" : "light"));
+  });
 </script>
 
 <svelte:head>
@@ -8,4 +36,9 @@
   <meta name="description" content="提供高雄市各區景點資訊、開放時間、地址、電話及票價查詢，並可依區域篩選和瀏覽熱門景點。" />
 </svelte:head>
 
-<slot />
+<div
+  class="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-slate-50 text-slate-900 transition-colors duration-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900 dark:text-slate-100"
+>
+  <slot />
+  <ThemeToggle {theme} on:toggle={toggleTheme} />
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -108,24 +108,24 @@
 </header>
 <!-- 主要內容 -->
 <main class="container mx-auto pb-12">
-  <div class="-mt-10 mx-2 rounded-3xl border border-indigo-100 bg-white/90 py-5 px-6 text-center shadow-lg backdrop-blur">
-    <h2 class="mb-2 text-2xl font-semibold text-indigo-600">💯 熱門景點 💯</h2>
+  <div class="-mt-10 mx-2 rounded-3xl border border-indigo-100 bg-white/90 py-5 px-6 text-center shadow-lg backdrop-blur dark:border-slate-700 dark:bg-slate-900/70">
+    <h2 class="mb-2 text-2xl font-semibold text-indigo-600 dark:text-indigo-300">💯 熱門景點 💯</h2>
     <HotButtons {hotAreas} onSelect={handleSelect} />
   </div>
-  <h3 class="my-6 text-center text-2xl font-bold text-slate-700">
+  <h3 class="my-6 text-center text-2xl font-bold text-slate-700 dark:text-slate-100">
     {selected || "全部景點"}
   </h3>
   {#if isLoading}
     <section class="my-12 space-y-5" role="status" aria-live="polite">
-      <div class="text-center text-indigo-600">
+      <div class="text-center text-indigo-600 dark:text-indigo-200">
         <p class="text-lg font-semibold">資料載入中，請稍候…</p>
-        <p class="text-sm text-slate-500">正在取得高雄各區景點資訊</p>
+        <p class="text-sm text-slate-500 dark:text-slate-300">正在取得高雄各區景點資訊</p>
       </div>
       <LoadingSkeleton />
       <span class="sr-only">載入中</span>
     </section>
   {:else if errorMessage}
-    <p class="my-4 text-center text-xl font-semibold text-rose-500">{errorMessage}</p>
+    <p class="my-4 text-center text-xl font-semibold text-rose-500 dark:text-rose-300">{errorMessage}</p>
   {:else if pageItems.length > 0}
     <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {#each pageItems as item (item.Name)}
@@ -134,11 +134,11 @@
     </ul>
     {#if totalPages > 1}
       <nav class="mt-8 flex justify-center" aria-label="景點分頁">
-        <ul class="inline-flex items-stretch overflow-hidden rounded-full border border-indigo-200 bg-white shadow">
+        <ul class="inline-flex items-stretch overflow-hidden rounded-full border border-indigo-200 bg-white shadow dark:border-slate-700 dark:bg-slate-900">
           <li>
             <button
               class="flex items-center gap-1 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50
-                cursor-pointer disabled:text-gray-400 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+                cursor-pointer disabled:text-gray-400 disabled:hover:bg-transparent disabled:cursor-not-allowed dark:text-indigo-200 dark:hover:bg-slate-800"
               on:click={() => goToPage(currentPage - 1)}
               disabled={currentPage === 1}
               type="button"
@@ -153,10 +153,10 @@
             <li>
               <button
                 class={`px-4 py-2 text-sm font-semibold transition cursor-pointer focus-visible:outline focus-visible:outline-2
-                  focus-visible:outline-indigo-500 ${
+                  focus-visible:outline-indigo-500 dark:focus-visible:outline-indigo-300 ${
                   page === currentPage
-                    ? "bg-indigo-600 text-white shadow-inner"
-                    : "text-indigo-600 hover:bg-indigo-50"
+                    ? "bg-indigo-600 text-white shadow-inner dark:bg-indigo-500"
+                    : "text-indigo-600 hover:bg-indigo-50 dark:text-indigo-200 dark:hover:bg-slate-800"
                 }`}
                 type="button"
                 aria-current={page === currentPage ? "page" : undefined}
@@ -169,7 +169,7 @@
           <li>
             <button
               class="flex items-center gap-1 px-4 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-50
-                cursor-pointer disabled:text-gray-400 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+                cursor-pointer disabled:text-gray-400 disabled:hover:bg-transparent disabled:cursor-not-allowed dark:text-indigo-200 dark:hover:bg-slate-800"
               on:click={() => goToPage(currentPage + 1)}
               disabled={currentPage === totalPages}
               type="button"
@@ -183,6 +183,6 @@
       </nav>
     {/if}
   {:else}
-    <p class="my-4 text-center text-2xl text-slate-500">目前沒有任何景點</p>
+    <p class="my-4 text-center text-2xl text-slate-500 dark:text-slate-300">目前沒有任何景點</p>
   {/if}
 </main>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 // Tailwind CSS 設定檔，用於掃描專案檔案與控制主題選項
 module.exports = {
+  darkMode: "class",
   content: ["./src/**/*.{html,js,svelte,ts}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- upgrade SvelteKit, Vite, and Svelte to the latest patch releases
- add a persistent light/dark theme toggle with shared styling variables
- update UI elements (cards, pagination, loading skeleton) to follow the active theme and document the new behavior

## Testing
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69344d8c9d70833081ac88b2ce01c870)